### PR TITLE
Fix remaining specs for node4

### DIFF
--- a/lib/peerconnection.js
+++ b/lib/peerconnection.js
@@ -216,8 +216,6 @@ function RTCPeerConnection(configuration, constraints) {
       },
       onError: failureCallback
     });
-
-    return pc.createOffer(successCallback, failureCallback, options);
   };
 
   this.createAnswer = function createAnswer(successCallback, failureCallback, options) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "fs-extra": "^0.18.0",
     "nan": "^2.1.0",
-    "node-gyp": "^1.0.1",
+    "node-gyp": "^3.0.3",
     "node-pre-gyp": "0.6.x",
     "node-static-alias": "^0.1.2",
     "nopt": "^2.2.0"

--- a/src/peerconnection.cc
+++ b/src/peerconnection.cc
@@ -117,7 +117,7 @@ void PeerConnection::Run(uv_async_t* handle, int status)
       PeerConnection::SdpEvent* data = static_cast<PeerConnection::SdpEvent*>(evt.data);
       v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(pc->Get(Nan::New("onsuccess").ToLocalChecked()));
       v8::Local<v8::Value> argv[1];
-      argv[0] = Nan::New(&data->desc);
+      argv[0] = Nan::New(data->desc.c_str()).ToLocalChecked();
       Nan::MakeCallback(pc, callback, 1, argv);
     } else if(PeerConnection::GET_STATS_SUCCESS & evt.type)
     {
@@ -173,8 +173,8 @@ void PeerConnection::Run(uv_async_t* handle, int status)
       if(!callback.IsEmpty())
       {
         v8::Local<v8::Value> argv[3];
-        argv[0] = Nan::New(&data->candidate);
-        argv[1] = Nan::New(&data->sdpMid);
+        argv[0] = Nan::New(data->candidate.c_str()).ToLocalChecked();
+        argv[1] = Nan::New(data->sdpMid.c_str()).ToLocalChecked();
         argv[2] = Nan::New<Integer>(data->sdpMLineIndex);
         Nan::MakeCallback(pc, callback, 3, argv);
       }
@@ -463,9 +463,9 @@ NAN_GETTER(PeerConnection::GetLocalDescription) {
   if(NULL == sdi) {
     value = Nan::Null();
   } else {
-    std::string *sdp;
-    sdi->ToString(sdp);
-    value = Nan::New(sdp);
+    std::string sdp;
+    sdi->ToString(&sdp);
+    value = Nan::New(sdp.c_str()).ToLocalChecked();
   }
 
   TRACE_END;
@@ -483,9 +483,9 @@ NAN_GETTER(PeerConnection::GetRemoteDescription) {
   if(NULL == sdi) {
     value = Nan::Null();
   } else {
-    std::string *sdp;
-    sdi->ToString(sdp);
-    value = Nan::New(sdp);
+    std::string sdp;
+    sdi->ToString(&sdp);
+    value = Nan::New(sdp.c_str()).ToLocalChecked();
   }
 
   TRACE_END;


### PR DESCRIPTION
Hey @substack, with these changes the tests pass and the examples run in node 4. Maybe there's a better way to do these? I dunno, I was banging my head on it till it worked. Also, do you think we should bump node-gyp? I was able to build fine on the latest, `3.0.3`.